### PR TITLE
Add 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ test:
     - pip check  # [not (win and python_impl == 'pypy')]
   requires:
     - pip
+    - python <3.10
 
 about:
   home: https://pypi.org/project/pep517/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: True  # [py<36]
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,21 +11,19 @@ source:
   sha256: 931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0
 
 build:
+  skip: True  # [py<36]
   number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
     - pip
-    - flit-core >=2,<3
+    - flit-core >=2,<4
   run:
     - python
     - importlib_metadata  # [py<38]
-    - tomli  # [py>=36]
+    - tomli >=1.1.0  # [py>=36]
     - zipp  # [py<38]
 
 test:
@@ -41,6 +39,7 @@ about:
   home: https://pypi.org/project/pep517/
   summary: Wrappers to build Python packages using PEP 517 hooks
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/pypa/pep517
+  doc_url: https://pep517.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Requirements from conda-forge: https://github.com/conda-forge/pep517-feedstock/blob/master/recipe/meta.yaml
Bug Tracker: new open issues https://pypi.org/project/pep517//issues
Releases:  https://pep517.readthedocs.io/en/latest/changelog.html
Upstream license: https://github.com/pypa/pep517/blob/v0.12.0/LICENSE
Upstream setup file: https://github.com/pypa/pep517/blob/v0.12.0/pyproject.toml

The package pep517 is mentioned inside the packages:
python-build |

Actions:
1. Skip py<36
2. Update dependencies
3. Add license_family, dev, doc urls
4. Add python <3.10 to test/requires
5. Reset the build number to 0

Result:
- all-fail